### PR TITLE
Add keywords and order field in the bugzilla graphql gateway

### DIFF
--- a/src/graphql/Bug.graphql
+++ b/src/graphql/Bug.graphql
@@ -199,6 +199,9 @@ input BugSearch {
   # The numeric IDs of bugs.
   ids: [Int]
 
+  # Each keyword that is on this bug.
+  keywords: [String]
+
   # Searches for bugs that were modified at this time or later.
   modifiedAtOrAfter: DateTime
 
@@ -209,6 +212,9 @@ input BugSearch {
 
   # The "Operating System" fields of bugs.
   operatingSystems: [String]
+
+  # The ordering of the result in the format of <field>[,<field>...][" DESC"|" ASC"]
+  order: String
 
   # The platforms (sometimes called "Hardware") fields of bugs.
   platforms: [String]


### PR DESCRIPTION
Add keywords field to filter based on keywords (e.g `"keywords": ["good-first-bug"]`) and order field to sort the bug result based on https://bugzilla.mozilla.org/show_bug.cgi?id=1172787 (e.g `"order": "bug_id DESC"`)