### PR TITLE
Fix fieldsToIncludeFields method to handle nested queries

### DIFF
--- a/src/mappings.js
+++ b/src/mappings.js
@@ -70,10 +70,12 @@ export const fieldsToIncludeFields = fields => {
 
   return fields
     .map(field => {
-      if (common.includes(field)) {
-        return field;
-      } else if (inputMappings.includes(field)) {
-        return mappings[field];
+      const lastField = field.substr(field.lastIndexOf('.') + 1);
+
+      if (common.includes(lastField)) {
+        return lastField;
+      } else if (inputMappings.includes(lastField)) {
+        return mappings[lastField];
       }
 
       return undefined;

--- a/src/mappings.js
+++ b/src/mappings.js
@@ -69,13 +69,13 @@ export const fieldsToIncludeFields = fields => {
   const inputMappings = Object.keys(mappings);
 
   return fields
-    .map(field => {
-      const lastField = field.substr(field.lastIndexOf('.') + 1);
+    .map(nestedField => {
+      const field = nestedField.split('.').slice(-1)[0];
 
-      if (common.includes(lastField)) {
-        return lastField;
-      } else if (inputMappings.includes(lastField)) {
-        return mappings[lastField];
+      if (common.includes(field)) {
+        return field;
+      } else if (inputMappings.includes(field)) {
+        return mappings[field];
       }
 
       return undefined;

--- a/src/mappings.js
+++ b/src/mappings.js
@@ -78,6 +78,8 @@ export const fieldsToIncludeFields = fields => {
         return lastField;
       } else if (inputMappings.includes(lastField)) {
         return mappings[lastField];
+      } else if (field.includes('assignedTo')) {
+        return mappings.assignedTos;
       }
 
       return undefined;

--- a/src/mappings.js
+++ b/src/mappings.js
@@ -69,8 +69,8 @@ export const fieldsToIncludeFields = fields => {
   const inputMappings = Object.keys(mappings);
 
   return fields
-    .map(nestedField => {
-      const field = nestedField.split('.').slice(-1)[0];
+    .map(f => {
+      const field = f.split('.').slice(-1)[0];
 
       if (common.includes(field)) {
         return field;

--- a/src/mappings.js
+++ b/src/mappings.js
@@ -69,13 +69,15 @@ export const fieldsToIncludeFields = fields => {
   const inputMappings = Object.keys(mappings);
 
   return fields
-    .map(f => {
-      const field = f.split('.').slice(-1)[0];
+    .map(field => {
+      // Use array destructuring to put the first item in the array
+      // in the lastField variable.
+      const [lastField] = field.split('.').slice(-1);
 
-      if (common.includes(field)) {
-        return field;
-      } else if (inputMappings.includes(field)) {
-        return mappings[field];
+      if (common.includes(lastField)) {
+        return lastField;
+      } else if (inputMappings.includes(lastField)) {
+        return mappings[lastField];
       }
 
       return undefined;


### PR DESCRIPTION
For nested query, it will return `edges.nodes.assignedTo.name`, thus no match is found
Example query:
```
query Bugs($search: BugSearch!, $paging: Paging) {
  bugs(search: $search, paging: $paging) {
    edges {
      node {
        assignedTo {
          name
        }
      }
    }
  }
}
```
The `listFields` method from `graphql-list-fields`will return :
```
[ 'edges.node.assignedTo.name',
  'edges.node.assignedTo.username']
```
thus when matched with `common` or `mappings`, it will return `undefined`
